### PR TITLE
Prevent to access not defined property

### DIFF
--- a/includes/class.cooked-post-types.php
+++ b/includes/class.cooked-post-types.php
@@ -295,7 +295,7 @@ class Cooked_Post_Types {
 				endif;
 				$cooked_taxonomies_for_menu[] = array(
 					'menu' => 'cooked_recipes_menu',
-					'name' => $args['labels']['menu_name'],
+					'name' => isset( $args['labels']['menu_name'] ) ? $args['labels']['menu_name'] : '',,
 					'capability' => 'manage_categories',
 					'url' => 'edit-tags.php?taxonomy=' . $slug . '&post_type=cp_recipe'
 				);


### PR DESCRIPTION
The value `labels` and `menu_name` are not always present so before accessing the values we first verify if the property exists inside of the associative array, otherwise fallback to an empty string.